### PR TITLE
Redesign Environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,21 +5,25 @@
 Genera
 ---
 
-Class field decorator `@EnvironmentVariable` (TypeScript 5, Stage 3 ECMAScript Decorators).
+Class field decorator `@EnvironmentVariable`. Depends on TypeScript 5, Stage 3 ECMAScript Decorators 
+and does not requires the opt-in compiler flag called `--experimentalDecorators`.
 
 ~~~TypeScript
-class MongoWorkerBuilder {
+export default class AwsEnvironmentMock {
 
-    @EnvironmentVariable("MONGODB_ATLAS_HOST")
-    private host: string = "";
+    @EnvironmentVariable("AWS_REGION_MOCK").orInitial()
+    private readonly awsRegion: string = "us-east-1";
 
-    @EnvironmentVariable("MONGODB_ATLAS_CERT")
-    private tlsCertificate: string = "";
+    @EnvironmentVariable("AWS_ACCOUNT_MOCK").orElseThrow()
+    private readonly awsAccount: string = "";
 
-    @EnvironmentVariable("MONGODB_ATLAS_KEY")
-    private tlsPrivateKey: string = "";
+    public region(): string {
+        return this.awsRegion;
+    }
 
-    ...
+    public account(): string {
+        return this.awsAccount;
+    }
 }
 ~~~
 

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
   "files": [
     "lib/"
   ],
-  "main": "lib/main/index.js",
-  "types": "lib/main/index.d.ts",
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/raccoons-co/genera.git"

--- a/src/main/ClassFieldDecorator.ts
+++ b/src/main/ClassFieldDecorator.ts
@@ -1,0 +1,20 @@
+/*
+ *  Copyright 2023, Raccoons. Developing simple way to change.
+ *
+ *  @license MIT
+ */
+
+import {Any, Method} from "@raccoons-co/genera";
+import {Strict} from "@raccoons-co/ethics";
+import Annotation from "./Annotation";
+
+export default class ClassFieldDecorator implements Annotation {
+
+    decorator(initializer: Method): Method {
+        return function newFieldInitializer(value: Any, context: ClassFieldDecoratorContext) {
+            Strict.notNull(context);
+            Strict.checkArgument(context.kind === "field");
+            return initializer;
+        };
+    }
+}

--- a/src/main/EnvironmentVariable.ts
+++ b/src/main/EnvironmentVariable.ts
@@ -5,29 +5,34 @@
  */
 
 import {Strict} from "@raccoons-co/ethics";
-import {Annotation, Any, Method} from "@raccoons-co/genera";
+import {Method} from "@raccoons-co/genera";
+import ClassFieldDecorator from "./ClassFieldDecorator";
 
 /**
  * The user environment variable.
+ *
+ * @param key - the name of the environment variable
+ * @returns object - the decorator factory instance
  */
-class EnvironmentVariable implements Annotation {
+export default function EnvironmentVariable(key: string) {
+    return new class DecoratorFactory {
 
-    /**
-     * Returns the class field decorator that replaces initial field value
-     * with value of user environment variable.
-     *
-     * @param key - the name of the environment variable
-     * @returns function - the class field decorator
-     */
-    decorator(key: string): Method {
-        Strict.notNull(key);
-        return function newFieldValue(value: Any, context: ClassFieldDecoratorContext) {
-            Strict.notNull(context);
-            Strict.checkArgument(context.kind === "field");
-            // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            return (initialValue: string) => Strict.notNull(process.env[key], `${key} is undefined`);
-        };
-    }
+        /** Returns decorator that replaces initial field value with value of user environment variable if defined. */
+        public orInitial(): Method {
+            return new ClassFieldDecorator().decorator(
+                (initialValue: string) => process.env[key] ?? initialValue
+            );
+        }
+
+        /**
+         * Returns decorator that replaces initial field value with value of defined user environment variable
+         * otherwise throws `NullPointerException`.
+         */
+        public orElseThrow(): Method {
+            return new ClassFieldDecorator().decorator(
+                // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                (initialValue: string) => Strict.notNull(process.env[key], `${key} is undefined`)
+            );
+        }
+    };
 }
-
-export default new EnvironmentVariable().decorator;

--- a/src/test/EnvironmentVariableTest.ts
+++ b/src/test/EnvironmentVariableTest.ts
@@ -1,17 +1,31 @@
-import {Test, TestClass} from "@raccoons-co/cleanway";
+import {BeforeEach, Test, TestClass} from "@raccoons-co/cleanway";
 import {assert} from "chai";
-import {EnvironmentVariable} from "../main";
-
-process.env.AWS_ACCOUNT_MOCK = "703521322927";
+import AwsEnvironmentMock from "./given/AwsEnvironmentMock";
 
 @TestClass
 export default class EnvironmentVariableTest {
 
-    @EnvironmentVariable("AWS_ACCOUNT_MOCK")
-    private readonly userEnvironmentVariable: string = "";
+    @BeforeEach
+    public setUp(): void {
+        process.env.AWS_ACCOUNT_MOCK = "703521322927";
+    }
 
     @Test
-    public setsClassFieldValue(): void {
-        assert.equal(this.userEnvironmentVariable, "703521322927");
+    public setsInitialValue(): void {
+        assert.equal(new AwsEnvironmentMock().region(), "us-east-1");
+    }
+
+    @Test
+    public setsValueFromUserEnvironment(): void {
+        process.env.AWS_REGION_MOCK = "us-west-1";
+        const awsEnvironment = new AwsEnvironmentMock();
+        assert.equal(awsEnvironment.region(), "us-west-1");
+        assert.equal(awsEnvironment.account(), "703521322927");
+    }
+
+    @Test
+    public throwsExceptionsIfUndefined(): void {
+        delete process.env.AWS_ACCOUNT_MOCK;
+        assert.throws(() => new AwsEnvironmentMock());
     }
 }

--- a/src/test/given/AwsEnvironmentMock.ts
+++ b/src/test/given/AwsEnvironmentMock.ts
@@ -1,0 +1,24 @@
+/*
+ *  Copyright 2023, Raccoons. Developing simple way to change.
+ *
+ *  @license MIT
+ */
+
+import {EnvironmentVariable} from "../../main";
+
+export default class AwsEnvironmentMock {
+
+    @EnvironmentVariable("AWS_REGION_MOCK").orInitial()
+    private readonly awsRegion: string = "us-east-1";
+
+    @EnvironmentVariable("AWS_ACCOUNT_MOCK").orElseThrow()
+    private readonly awsAccount: string = "";
+
+    public region(): string {
+        return this.awsRegion;
+    }
+
+    public account(): string {
+        return this.awsAccount;
+    }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -100,5 +100,5 @@
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
   },
-  "include": ["src/"]
+  "include": ["src/main"]
 }


### PR DESCRIPTION
~~~TypeScript
export default class AwsEnvironmentMock {

    @EnvironmentVariable("AWS_REGION_MOCK").orInitial()
    private readonly awsRegion: string = "us-east-1";

    @EnvironmentVariable("AWS_ACCOUNT_MOCK").orElseThrow()
    private readonly awsAccount: string = "";

    public region(): string {
        return this.awsRegion;
    }

    public account(): string {
        return this.awsAccount;
    }
}
~~~