### PR TITLE
Refactor `@EnvironmentVariable`

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ Class field decorator `@EnvironmentVariable`. Depends on TypeScript 5, Stage 3 E
 and does not requires the opt-in compiler flag called `--experimentalDecorators`.
 
 ~~~TypeScript
-export default class AwsEnvironmentMock {
+export default class AwsEnvironment {
 
-    @EnvironmentVariable("AWS_REGION_MOCK").orInitial()
+    @EnvironmentVariable.of("AWS_REGION").orElseInitial()
     private readonly awsRegion: string = "us-east-1";
 
-    @EnvironmentVariable("AWS_ACCOUNT_MOCK").orElseThrow()
+    @EnvironmentVariable.of("AWS_ACCOUNT").orElseThrow()
     private readonly awsAccount: string = "";
 
     public region(): string {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@raccoons-co/genera",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@raccoons-co/genera",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "devDependencies": {
         "@raccoons-co/cleanway": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@raccoons-co/genera",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Abstractions on top of Typescript 5.0.",
   "keywords": [
     "TypeScript",

--- a/src/main/EnvironmentVariable.ts
+++ b/src/main/EnvironmentVariable.ts
@@ -10,28 +10,34 @@ import ClassFieldDecorator from "./ClassFieldDecorator";
 
 /**
  * The user environment variable.
- *
- * @param key - the name of the environment variable
- * @returns object - the decorator factory instance
  */
-export default function environmentVariable(key: string): EnvironmentVariableDecoratorFactory {
-    return new class EnvironmentVariable implements EnvironmentVariableDecoratorFactory {
+export default class EnvironmentVariable {
 
-        /** {@inheritDoc} */
-        public orInitial(): Method {
-            return new ClassFieldDecorator().decorator(
-                (initialValue: string) => process.env[key] ?? initialValue
-            );
-        }
+    /**
+     * Returns environment variable decorator factory instance.
+     *
+     * @param name - the name of the environment variable
+     * @returns object - the decorator factory instance
+     */
+    public static of(name: string): EnvironmentVariableDecoratorFactory {
+        return new class implements EnvironmentVariableDecoratorFactory {
 
-        /** {@inheritDoc} */
-        public orElseThrow(): Method {
-            return new ClassFieldDecorator().decorator(
-                // eslint-disable-next-line @typescript-eslint/no-unused-vars
-                (initialValue: string) => Strict.notNull(process.env[key], `${key} is undefined`)
-            );
-        }
-    };
+            /** {@inheritDoc} */
+            public orElseInitial(): Method {
+                return new ClassFieldDecorator().decorator(
+                    (initialValue: string) => process.env[name] ?? initialValue
+                );
+            }
+
+            /** {@inheritDoc} */
+            public orElseThrow(): Method {
+                return new ClassFieldDecorator().decorator(
+                    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                    (initialValue: string) => Strict.notNull(process.env[name], `${name} is undefined`)
+                );
+            }
+        };
+    }
 }
 
 interface EnvironmentVariableDecoratorFactory {
@@ -40,7 +46,7 @@ interface EnvironmentVariableDecoratorFactory {
      * Returns decorator that replaces initial field value with value of user environment variable if defined
      * otherwise keeps initialized value.
      */
-    orInitial(): Method;
+    orElseInitial(): Method;
 
     /**
      * Returns decorator that replaces initial field value with value of user environment variable if defined

--- a/src/main/EnvironmentVariable.ts
+++ b/src/main/EnvironmentVariable.ts
@@ -14,20 +14,17 @@ import ClassFieldDecorator from "./ClassFieldDecorator";
  * @param key - the name of the environment variable
  * @returns object - the decorator factory instance
  */
-export default function EnvironmentVariable(key: string) {
-    return new class DecoratorFactory {
+export default function environmentVariable(key: string): EnvironmentVariableDecoratorFactory {
+    return new class EnvironmentVariable implements EnvironmentVariableDecoratorFactory {
 
-        /** Returns decorator that replaces initial field value with value of user environment variable if defined. */
+        /** {@inheritDoc} */
         public orInitial(): Method {
             return new ClassFieldDecorator().decorator(
                 (initialValue: string) => process.env[key] ?? initialValue
             );
         }
 
-        /**
-         * Returns decorator that replaces initial field value with value of defined user environment variable
-         * otherwise throws `NullPointerException`.
-         */
+        /** {@inheritDoc} */
         public orElseThrow(): Method {
             return new ClassFieldDecorator().decorator(
                 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -35,4 +32,19 @@ export default function EnvironmentVariable(key: string) {
             );
         }
     };
+}
+
+interface EnvironmentVariableDecoratorFactory {
+
+    /**
+     * Returns decorator that replaces initial field value with value of user environment variable if defined
+     * otherwise keeps initialized value.
+     */
+    orInitial(): Method;
+
+    /**
+     * Returns decorator that replaces initial field value with value of user environment variable if defined
+     * otherwise throws `NullPointerException`.
+     */
+    orElseThrow(): Method;
 }

--- a/src/test/given/AwsEnvironmentMock.ts
+++ b/src/test/given/AwsEnvironmentMock.ts
@@ -8,10 +8,10 @@ import {EnvironmentVariable} from "../../main";
 
 export default class AwsEnvironmentMock {
 
-    @EnvironmentVariable("AWS_REGION_MOCK").orInitial()
+    @EnvironmentVariable.of("AWS_REGION_MOCK").orElseInitial()
     private readonly awsRegion: string = "us-east-1";
 
-    @EnvironmentVariable("AWS_ACCOUNT_MOCK").orElseThrow()
+    @EnvironmentVariable.of("AWS_ACCOUNT_MOCK").orElseThrow()
     private readonly awsAccount: string = "";
 
     public region(): string {


### PR DESCRIPTION
~~~TypeScript
export default class AwsEnvironment {

    @EnvironmentVariable.of("AWS_REGION").orElseInitial()
    private readonly awsRegion: string = "us-east-1";

    @EnvironmentVariable.of("AWS_ACCOUNT").orElseThrow()
    private readonly awsAccount: string = "";

    public region(): string {
        return this.awsRegion;
    }

    public account(): string {
        return this.awsAccount;
    }
}